### PR TITLE
Fixing typo on line 346

### DIFF
--- a/docs/docs/api/elections.html
+++ b/docs/docs/api/elections.html
@@ -343,7 +343,7 @@ subtoc: api_elections_object
                     <a href="#election-type-local" class="permalink"></a>
                 </td>
                 <td>
-                    A regularly-scheduled local election convering all or the
+                    A regularly-scheduled local election covering all or the
                     majority of a local municipality or region.
                 </td>
             </tr>


### PR DESCRIPTION
I fixed "convering" in the sentence from line 346:
" A regularly-scheduled local election convering all or the majority of a local municipality or region."
It now reads:
"A regularly-scheduled local election covering all or the majority of a local municipality or region."